### PR TITLE
feat(beacon): update to 2.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@airgap/beacon-sdk": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-sdk/-/beacon-sdk-2.2.2.tgz",
-      "integrity": "sha512-B0tJ0WzttIgLLfo+WD1dbpEfzEkvCULsJi/He/UylGn805/HPoTc42TWnfbCCQ7sn0FtwlkttYy/RJRSCQw9BQ==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-sdk/-/beacon-sdk-2.2.5.tgz",
+      "integrity": "sha512-4DNh4aPl92+zFD/E5dC4WgAGYOjcJnSxzkBiQGR/oW74GTJe6hL9p0TBnJFqp5fHnqjBQSjT1zQmXG5TIZ3efw==",
       "requires": {
         "@types/chrome": "0.0.115",
         "@types/libsodium-wrappers": "0.7.7",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@airgap/beacon-sdk": "^2.1.0",
+    "@airgap/beacon-sdk": "^2.2.5",
     "@baking-bad/vjsf": "^1.20.11",
     "@sentry/browser": "^5.27.6",
     "@sentry/integrations": "^5.27.6",


### PR DESCRIPTION
Beacon SDK 2.2.5 fixes an issue that can prevent wallets like Kukai, AirGap and Galleon from connecting to dApps over the beacon network.