### PR TITLE
Fix `isDark` check to from localStorage value

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -155,7 +155,7 @@ api.getConfig().then(response => {
     });
   }
 
-  const isDark = localStorage.getItem('dark') ? localStorage.getItem : true;
+  const isDark = localStorage.getItem('dark') ? JSON.parse(localStorage.getItem('dark')) : true;
   if (isDark) {
     document.body.classList.add('dark-theme-background');
   }


### PR DESCRIPTION
Looks like this was a regression introduced in https://github.com/baking-bad/bcd/commit/c0ffc92df7b1aa65ab0c4a877d180896e3e6772f#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79R154, things will always evaluate to `true`. 

This PR fixes it by parsing whatever the value is as JSON so if it's `"true"` or `"false"` it should work properly, and then default to dark mode 👍!